### PR TITLE
Capitalise name of mod in ModMenu

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
 	"id": "chonk",
 	"version": "${version}",
 
-	"name": "chonk",
+	"name": "Chonk",
 	"description": "lode muh chonk",
 	"authors": [
 		"vktec"


### PR DESCRIPTION
If the name starts with a lowercase letter, it is sent to the bottom of the list (in ModMenu) and breaks alphabetical order. I believe this is a bug in ModMenu (which I have submitted an [issue report](https://github.com/TerraformersMC/ModMenu/issues/182) for), but it is easy to fix the issue for this mod by simply capitalising the name.