### PR TITLE
"Update" to 1.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.7-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-	id 'fabric-loom' version '0.2.7-SNAPSHOT'
+	id 'fabric-loom' version '0.8-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -17,16 +17,11 @@ dependencies {
 }
 
 processResources {
-	inputs.property "version", project.version
+    inputs.property "version", project.version
 
-	from(sourceSets.main.resources.srcDirs) {
-		include "fabric.mod.json"
-		expand "version": project.version
-	}
-
-	from(sourceSets.main.resources.srcDirs) {
-		exclude "fabric.mod.json"
-	}
+    filesMatching("fabric.mod.json") {
+        expand "version": project.version
+    }
 }
 
 // ensure that the encoding is set to UTF-8, no matter what the system default is

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,9 @@ version = project.mod_version
 group = project.maven_group
 
 dependencies {
-	minecraft "com.mojang:minecraft:${project.minecraft_version
-   	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    minecraft "com.mojang:minecraft:${project.minecraft_version
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -11,17 +11,17 @@ version = project.mod_version
 group = project.maven_group
 
 dependencies {
-	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+		minecraft "com.mojang:minecraft:${project.minecraft_version}"
+		mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+		modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 
 processResources {
-    inputs.property "version", project.version
+    	inputs.property "version", project.version
 
-    filesMatching("fabric.mod.json") {
-        expand "version": project.version
-    }
+    	filesMatching("fabric.mod.json") {
+        		expand "version": project.version
+    	}
 }
 
 // ensure that the encoding is set to UTF-8, no matter what the system default is

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,9 @@ version = project.mod_version
 group = project.maven_group
 
 dependencies {
-   minecraft "com.mojang:minecraft:${project.minecraft_version}"
-   mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-   modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	minecraft "com.mojang:minecraft:${project.minecraft_version
+   	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,9 @@ version = project.mod_version
 group = project.maven_group
 
 dependencies {
-    minecraft "com.mojang:minecraft:1.16.4"
-    mappings "net.fabricmc:yarn:1.16.4+build.7:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.10.8"
+	minecraft "com.mojang:minecraft:${project.minecraft_version}"
+	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -11,17 +11,17 @@ version = project.mod_version
 group = project.maven_group
 
 dependencies {
-    minecraft "com.mojang:minecraft:${project.minecraft_version
-    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	minecraft "com.mojang:minecraft:${project.minecraft_version
+	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 
 processResources {
 	inputs.property "version", project.version
 
-    	filesMatching("fabric.mod.json") {
-        		expand "version": project.version
-    	}
+	filesMatching("fabric.mod.json") {
+		expand "version": project.version
+	}
 }
 
 // ensure that the encoding is set to UTF-8, no matter what the system default is

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,9 @@ version = project.mod_version
 group = project.maven_group
 
 dependencies {
-  minecraft "com.mojang:minecraft:${project.minecraft_version}"
-  mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-  modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+   minecraft "com.mojang:minecraft:${project.minecraft_version}"
+   mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+   modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,9 @@ version = project.mod_version
 group = project.maven_group
 
 dependencies {
-	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+  minecraft "com.mojang:minecraft:${project.minecraft_version}"
+  mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+  modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,9 @@ version = project.mod_version
 group = project.maven_group
 
 dependencies {
-	minecraft "com.mojang:minecraft:${project.minecraft_version
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    minecraft "com.mojang:minecraft:${project.minecraft_version}"
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 }
 
 processResources {
-    	inputs.property "version", project.version
+		inputs.property "version", project.version
 
     	filesMatching("fabric.mod.json") {
         		expand "version": project.version

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,9 @@ version = project.mod_version
 group = project.maven_group
 
 dependencies {
-		minecraft "com.mojang:minecraft:${project.minecraft_version}"
-		mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-		modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	minecraft "com.mojang:minecraft:${project.minecraft_version}"
+	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 }
 
 processResources {
-		inputs.property "version", project.version
+	inputs.property "version", project.version
 
     	filesMatching("fabric.mod.json") {
         		expand "version": project.version

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-minecraft_version=1.16.4
-yarn_mappings=1.16.4+build.7
-loader_version=0.10.8
+minecraft_version=1.17
+yarn_mappings=1.17+build.13
+loader_version=0.11.6
 
 # Mod Properties
 mod_version = 0.1.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
 	],
 
 	"depends": {
-		"fabricloader": ">=0.7.4",
-		"minecraft": "1.16.x"
+		"fabricloader": ">=0.11.3",
+		"minecraft": "1.17.x"
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,6 +23,6 @@
 
 	"depends": {
 		"fabricloader": ">=0.11.3",
-		"minecraft": "1.17.x"
+		"minecraft": [ "1.16.x", "1.17.x" ]
 	}
 }


### PR DESCRIPTION
This mod already works on 1.17 (except for the version lock), but this just makes the mod officially for 1.17, so any future development work is for 1.17, and so that you can use JDK 16 features.